### PR TITLE
Fix heroku build error

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -10,7 +10,7 @@
     "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
@@ -69,5 +69,6 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-    "include": ["."]
+    "include": ["."],
+    "exclude": ["server_build/**/*"]
 }

--- a/server/tsconfig.prod.json
+++ b/server/tsconfig.prod.json
@@ -2,5 +2,5 @@
   "extends": "./tsconfig",
     // exclude files that are in the tests folder for prod build, since they are
     // devDependencies anyways, the build would fail in a prod environment (e.g. Heroku)
-  "exclude": ["/tests/**/*"]
+  "exclude": ["/tests/**/*", "server_build/**/*"]
 }


### PR DESCRIPTION
Since our testing infra doesn't run on the prod build,
some errors, specially build errors happen sometimes.
This fixes the error of config/config.js file being missing